### PR TITLE
Added TerritoriesService and TerritoriesVariable to make territories data available in front-end templates even when not using a field.

### DIFF
--- a/territories/services/TerritoriesService.php
+++ b/territories/services/TerritoriesService.php
@@ -1,0 +1,38 @@
+<?php
+namespace Craft;
+
+/**
+ * TerritoriesService
+ */
+class TerritoriesService extends BaseApplicationComponent
+{
+
+	private $_territories;
+
+	/**
+	 * Return an array of available territories
+	 *
+	 * @return array
+	 */
+	public function getTerritories()
+	{
+		if( ! isset($this->_territories))
+		{
+			Craft::import('plugins.territories.libraries.TerritoriesLocaleData');
+			$locale = TerritoriesLocaleData::getInstance(craft()->locale->getId());
+
+			$this->_territories = array();
+			foreach($locale->getTerritories() as $key => $val)
+			{
+				// skip non-integer keys
+				if( ! is_numeric($key))
+				{
+					$this->_territories[$key] = $val;
+				}
+			}
+		}
+
+		return $this->_territories;
+	}
+
+}

--- a/territories/variables/TerritoriesVariable.php
+++ b/territories/variables/TerritoriesVariable.php
@@ -1,0 +1,20 @@
+<?php
+namespace Craft;
+
+/**
+ * TerritoriesVariable
+ */
+class TerritoriesVariable
+{
+
+	/**
+	 * Return an array of available territories from the TerritoriesService
+	 *
+	 * @return array
+	 */
+	function getTerritories()
+	{
+		return craft()->territories->getTerritories();
+	}
+
+}


### PR DESCRIPTION
Added TerritoriesService and TerritoriesVariable to make territories data available in front-end templates even when not using a field.

This introduces duplication of the getTerritories() method, but I think the Fieldtype could be made to use the service to retrieve that data. Eventually I would hope to also replicate the getAvailableTerritories() functionality into the service so that ad-hoc inputs could be created directly in templates (independent of any custom field) by providing some ad-hoc settings parameters.